### PR TITLE
feat: email form 유효성 검사 

### DIFF
--- a/apps/client/app/login/page.tsx
+++ b/apps/client/app/login/page.tsx
@@ -56,7 +56,7 @@ const LoginPage = () => {
               />
             </InputContainer>
           </div>
-          <Button label="로그인" variant="blue" state={isValid ? "active" : "default"} />
+          <Button label="로그인" variant="blue" state={isValid ? "active" : "disabled"} />
         </form>
       </AuthForm>
     </div>

--- a/apps/client/app/login/page.tsx
+++ b/apps/client/app/login/page.tsx
@@ -56,7 +56,7 @@ const LoginPage = () => {
               />
             </InputContainer>
           </div>
-          <Button label="로그인" variant="blue" state={isValid ? "active" : "disabled"} />
+          <Button label="로그인" variant="blue" state={isValid ? "default" : "disabled"} />
         </form>
       </AuthForm>
     </div>

--- a/apps/client/app/login/page.tsx
+++ b/apps/client/app/login/page.tsx
@@ -5,18 +5,18 @@ import { useForm } from "react-hook-form";
 import { AuthForm } from "../../src/widgets/auth/ui";
 import { usePostSignin } from "../../src/entities/signin/model/usePostSignin";
 import { InputContainer } from "@repo/ui/widgets/inputContainer/index";
-import { LoginFormProps } from "../../src/shared/model/AuthForm";
+import { SigninFormProps } from "../../src/shared/model/AuthForm";
 
 const LoginPage = () => {
   const {
     control,
     handleSubmit,
     formState: { isValid },
-  } = useForm<LoginFormProps>({ mode: "onChange", defaultValues: { email: "", password: "" } });
+  } = useForm<SigninFormProps>({ mode: "onChange", defaultValues: { email: "", password: "" } });
 
   const { mutate: postSignin } = usePostSignin();
 
-  const onSubmit = (form: LoginFormProps) => {
+  const onSubmit = (form: SigninFormProps) => {
     postSignin(form);
   };
 
@@ -25,7 +25,7 @@ const LoginPage = () => {
       <AuthForm label="LOG IN">
         <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col items-center w-[25rem] gap-[3.625rem]">
           <div className="flex flex-col gap-[0.75rem] self-stretch">
-            <InputContainer label="이메일" >
+            <InputContainer label="이메일">
               <Input
                 name="email"
                 control={control}
@@ -38,7 +38,7 @@ const LoginPage = () => {
                 }}
               />
             </InputContainer>
-            <InputContainer label="비밀번호" >
+            <InputContainer label="비밀번호">
               <Input
                 name="password"
                 control={control}
@@ -56,7 +56,7 @@ const LoginPage = () => {
               />
             </InputContainer>
           </div>
-          <Button label="로그인" variant="blue" isActive={isValid} />
+          <Button label="로그인" variant="blue" state={isValid ? "active" : "default"} />
         </form>
       </AuthForm>
     </div>

--- a/apps/client/src/entities/main/ui/showLogin.tsx
+++ b/apps/client/src/entities/main/ui/showLogin.tsx
@@ -6,17 +6,15 @@ const ShowLogin = () => {
     <div className="m-4 sm:mt-[1.88rem] sm:mb-[6rem]">
       <h1 className="text-body3s sm:text-titleSmall">로그인 후</h1>
       <div className="flex items-center gap-1">
-        <h1 className="text-body2s sm:text-titleMedium text-tropicalblue-800">
-          GSMC{" "}
-        </h1>
+        <h1 className="text-body2s sm:text-titleMedium text-tropicalblue-800">GSMC </h1>
         <h1 className="text-body3s sm:text-titleSmall"> 를 이용해주세요</h1>
       </div>
       <div className="flex flex-col sm:flex-row gap-2 mt-4 sm:mt-[1.88rem]">
         <Link className="w-full" href="/login">
-          <Button label="로그인" isActive variant="blue" />
+          <Button label="로그인" state="default" variant="blue" />
         </Link>
         <Link className="w-full" href="/signup">
-          <Button label="회원가입" isActive variant="skyblue" />
+          <Button label="회원가입" state="default" variant="skyblue" />
         </Link>
       </div>
     </div>

--- a/apps/client/src/entities/signin/api/postSignin.ts
+++ b/apps/client/src/entities/signin/api/postSignin.ts
@@ -1,8 +1,8 @@
 import instance from "../../../../../../packages/ui/src/axios";
 import axios from "axios";
-import { SignupFormProps } from "../../../shared/model/AuthForm";
+import { SigninFormProps } from "../../../shared/model/AuthForm";
 
-export const postSignin = async (form: SignupFormProps) => {
+export const postSignin = async (form: SigninFormProps) => {
   try {
     const response = await instance.post(`/auth/signin`, form);
     return response.data;

--- a/apps/client/src/entities/signin/model/usePostSignin.ts
+++ b/apps/client/src/entities/signin/model/usePostSignin.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postSignin } from "../api/postSignin";
-import { SignupFormProps } from "../../../shared/model/AuthForm";
+import { SigninFormProps } from "../../../shared/model/AuthForm";
 
 export const usePostSignin = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (form: SignupFormProps) => postSignin(form),
+    mutationFn: (form: SigninFormProps) => postSignin(form),
     onSuccess: (data) => {
       if (data.accessToken) {
         localStorage.setItem("accessToken", data.accessToken);

--- a/apps/client/src/shared/model/AuthForm.ts
+++ b/apps/client/src/shared/model/AuthForm.ts
@@ -1,9 +1,9 @@
-export interface LoginFormProps {
+export interface SigninFormProps {
   email: string;
   password: string;
 }
 
-export interface SignupFormProps extends LoginFormProps {
+export interface SignupFormProps extends SigninFormProps {
   name: string;
   authcode: string;
   passwordCheck: string;

--- a/apps/client/src/widgets/stepAuthCode/ui/index.tsx
+++ b/apps/client/src/widgets/stepAuthCode/ui/index.tsx
@@ -62,7 +62,7 @@ export default function StepAuthCode({
           <Button
             label={isLoading ? "전송 중..." : "인증번호"}
             variant="blue"
-            isActive={isAuthButtonActive && !isLoading}
+            state={isAuthButtonActive && !isLoading ? "active" : "default"}
             onClick={handleAuthButtonClick}
           />
         </div>

--- a/packages/ui/src/input.tsx
+++ b/packages/ui/src/input.tsx
@@ -1,7 +1,6 @@
-"use client"
-import React from "react";
+"use client";
+import React, { useState, useEffect, useRef } from "react";
 import { useController, UseControllerProps, FieldValues } from "react-hook-form";
-
 
 interface InputProps<T extends FieldValues = FieldValues> extends UseControllerProps<T> {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -10,15 +9,153 @@ interface InputProps<T extends FieldValues = FieldValues> extends UseControllerP
 
 export const Input = <T extends FieldValues = FieldValues>({ type, ...props }: InputProps<T>) => {
   const { field } = useController(props);
+  const [displayValue, setDisplayValue] = useState<string>("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  // name이 password이면 password 타입으로, 아니면 주어진 type이나 기본값 text 사용
-  const inputType = field.name === "password" ? "password" : type || "text";
+  const isEmail = field.name === "email";
+  const suffix = "@gsm.hs.kr";
+
+  const isValidEmailPrefix = (value: string): boolean => {
+    if (value.length > 6) return false;
+    if (value.length > 0 && !/^[0-9s]/.test(value)) return false;
+    if (value.length > 1 && !/^[0-9s][0-9]*$/.test(value)) return false;
+    return true;
+  };
+
+  useEffect(() => {
+    if (isEmail && typeof field.value === "string") {
+      const valueWithoutSuffix = field.value.endsWith(suffix) ? field.value.slice(0, -suffix.length) : field.value;
+      setDisplayValue(valueWithoutSuffix);
+    } else {
+      setDisplayValue(field.value || "");
+    }
+  }, [field.value, isEmail]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+
+    if (isEmail) {
+      if (newValue.endsWith(suffix)) {
+        const prefix = newValue.slice(0, newValue.length - suffix.length);
+        if (isValidEmailPrefix(prefix)) {
+          setDisplayValue(prefix);
+          field.onChange(prefix + suffix);
+        }
+      } else {
+        const cursorPosition = e.target.selectionStart || 0;
+        const currentValueLength = displayValue.length;
+
+        if (cursorPosition <= currentValueLength) {
+          const newPrefix =
+            newValue.length > currentValueLength + suffix.length ? newValue.slice(0, -suffix.length) : newValue;
+
+          if (isValidEmailPrefix(newPrefix)) {
+            setDisplayValue(newPrefix);
+            field.onChange(newPrefix + suffix);
+          }
+        } else {
+          e.target.value = displayValue + suffix;
+        }
+      }
+    } else {
+      setDisplayValue(newValue);
+      field.onChange(newValue);
+    }
+  };
+
+  const handleSelect = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    if (isEmail && inputRef.current) {
+      const input = e.target as HTMLInputElement;
+      const prefixLength = displayValue.length;
+
+      if (input.selectionEnd && input.selectionEnd > prefixLength) {
+        input.setSelectionRange(input.selectionStart || 0, prefixLength);
+      }
+    }
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    if (isEmail && inputRef.current) {
+      const input = e.target as HTMLInputElement;
+      const prefixLength = displayValue.length;
+
+      if (input.selectionStart && input.selectionStart > prefixLength) {
+        input.setSelectionRange(prefixLength, prefixLength);
+      }
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (isEmail && inputRef.current) {
+      const input = e.target as HTMLInputElement;
+      const prefixLength = displayValue.length;
+      const cursorPosition = input.selectionStart || 0;
+
+      // 접미사 부분에 입력 금지
+      if (cursorPosition > prefixLength) {
+        const allowedKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "Tab"];
+        if (!allowedKeys.includes(e.key)) {
+          e.preventDefault();
+        }
+        return;
+      }
+
+      // 이메일 접두사 입력 제한 처리
+      if (isEmail) {
+        // 백스페이스와 삭제 키, 화살표 등 항상 허용
+        const alwaysAllowedKeys = [
+          "Backspace",
+          "Delete",
+          "ArrowLeft",
+          "ArrowRight",
+          "ArrowUp",
+          "ArrowDown",
+          "Home",
+          "End",
+          "Tab",
+        ];
+        if (alwaysAllowedKeys.includes(e.key)) {
+          return;
+        }
+
+        // 첫 글자에는 숫자와 's'만 허용
+        if (cursorPosition === 0) {
+          if (!/^[0-9s]$/.test(e.key)) {
+            e.preventDefault();
+          }
+        }
+        // 나머지 글자는 숫자만 허용
+        else {
+          if (!/^[0-9]$/.test(e.key)) {
+            e.preventDefault();
+          }
+        }
+
+        // 최대 6글자까지만 입력 가능
+        if (
+          displayValue.length >= 6 &&
+          !e.ctrlKey &&
+          !e.metaKey &&
+          !(input.selectionEnd && input.selectionStart !== input.selectionEnd)
+        ) {
+          e.preventDefault();
+        }
+      }
+    }
+  };
 
   return (
     <input
+      ref={inputRef}
       className="px-[1rem] py-[0.75rem] rounded-[0.75rem] border focus: outline-tropicalblue-500 bg-white ui-outline-gray-600"
-      type={inputType}
-      {...field}
+      type={field.name === "password" ? "password" : type || "text"}
+      value={isEmail ? `${displayValue}${suffix}` : displayValue}
+      onChange={handleChange}
+      onSelect={handleSelect}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onBlur={field.onBlur}
+      name={field.name}
     />
   );
-}
+};

--- a/packages/ui/src/input.tsx
+++ b/packages/ui/src/input.tsx
@@ -91,7 +91,13 @@ export const Input = <T extends FieldValues = FieldValues>({ type, ...props }: I
       const prefixLength = displayValue.length;
       const cursorPosition = input.selectionStart || 0;
 
-      // 접미사 부분에 입력 금지
+      if (e.key === "a" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        const fullLength = (displayValue + suffix).length;
+        input.setSelectionRange(0, fullLength);
+        return;
+      }
+
       if (cursorPosition > prefixLength) {
         const allowedKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "Tab"];
         if (!allowedKeys.includes(e.key)) {
@@ -100,9 +106,7 @@ export const Input = <T extends FieldValues = FieldValues>({ type, ...props }: I
         return;
       }
 
-      // 이메일 접두사 입력 제한 처리
       if (isEmail) {
-        // 백스페이스와 삭제 키, 화살표 등 항상 허용
         const alwaysAllowedKeys = [
           "Backspace",
           "Delete",
@@ -118,20 +122,16 @@ export const Input = <T extends FieldValues = FieldValues>({ type, ...props }: I
           return;
         }
 
-        // 첫 글자에는 숫자와 's'만 허용
         if (cursorPosition === 0) {
           if (!/^[0-9s]$/.test(e.key)) {
             e.preventDefault();
           }
-        }
-        // 나머지 글자는 숫자만 허용
-        else {
+        } else {
           if (!/^[0-9]$/.test(e.key)) {
             e.preventDefault();
           }
         }
 
-        // 최대 6글자까지만 입력 가능
         if (
           displayValue.length >= 6 &&
           !e.ctrlKey &&


### PR DESCRIPTION
## 💡 배경 및 개요

API에서 정확한 이메일 형식을 요구하도록 변경됨에 따라 Input 컴포넌트의 기능을 확장했습니다.

## 📃 작업내용

- SignUpForm 및 SignInForm에서 이메일 형식과 다른 문자를 입력할 수 없도록 검증 로직을 강화했습니다.
- 사용자의 입력 값 뒤에는 항상 @gsm.hs.kr 접미사가 자동으로 붙으며, 해당 문자열을 사용자가 수정할 수 없도록 고정 처리했습니다.

https://github.com/user-attachments/assets/6752a26c-473c-40bf-acf4-35f1827e25b4

